### PR TITLE
New swipe actions: Records, soft and hard delete

### DIFF
--- a/KlockWork-iOS/KlockWork-iOS/SharedViews/Tabs.Content.Individual.swift
+++ b/KlockWork-iOS/KlockWork-iOS/SharedViews/Tabs.Content.Individual.swift
@@ -95,7 +95,7 @@ extension Tabs.Content {
                 .foregroundStyle((self.record?.job?.backgroundColor ?? Theme.rowColour).isBright() ? .black : .white)
                 .onAppear(perform: self.actionOnAppear)
                 .swipeActions(edge: .trailing) {
-                    Button(role: .destructive) {
+                    Button {
                         self.actionOnSoftDelete()
 
                         if let onDelete = self.onActionDelete {
@@ -106,7 +106,21 @@ extension Tabs.Content {
                             onAction()
                         }
                     } label: {
-                        Image(systemName: "xmark")
+                        Image(systemName: "eye.slash")
+                    }
+                    .tint(.purple)
+                    Button(role: .destructive) {
+                        self.actionOnHardDelete()
+
+                        if let onDelete = self.onActionDelete {
+                            onDelete()
+                        }
+
+                        if let onAction = self.onAction {
+                            onAction()
+                        }
+                    } label: {
+                        Image(systemName: "trash")
                     }
                     .tint(.red)
                 }


### PR DESCRIPTION
Added a trailing swipe action to Records to make hiding and deleting them easy. Hide, soft delete, is the primary swipe action so it can be easily reversed. Hard delete doesn't prompt before deleting yet.